### PR TITLE
#5 - Added VS2017 and VS2019 F# SDK paths to rename.cmd

### DIFF
--- a/rename.cmd
+++ b/rename.cmd
@@ -1,6 +1,10 @@
 @echo off
-:: Add the paths for the F# SDK 4.x (from higher version to lower)
+:: Add the paths for the F# SDK (from higher version to lower)
 set FSHARPSDK=^
+C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\FSharp;^
+C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\FSharp;^
+C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\FSharp;^
+C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\IDE\CommonExtensions\Microsoft\FSharp;^
 C:\Program Files (x86)\Microsoft SDKs\F#\4.1\Framework\v4.0\;^
 C:\Program Files (x86)\Microsoft SDKs\F#\4.0\Framework\v4.0\;^
 C:\Program Files (x86)\Microsoft SDKs\F#\3.1\Framework\v4.0\;^


### PR DESCRIPTION
On a clean VS2017/VS2019 developer environment, F# SDK is located under Visual Studio folders.