### PR TITLE
Added generic function to get a manager from within another manager

### DIFF
--- a/XrmOrg/XrmOrg.XrmSolution/BusinessLogic/BusinessLogic.csproj
+++ b/XrmOrg/XrmOrg.XrmSolution/BusinessLogic/BusinessLogic.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Helpers\HelperUtils.cs" />
     <Compile Include="ManagerAccount.cs" />
     <Compile Include="ManagerBase.cs" />
+    <Compile Include="ManagerContact.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/XrmOrg/XrmOrg.XrmSolution/BusinessLogic/ManagerBase.cs
+++ b/XrmOrg/XrmOrg.XrmSolution/BusinessLogic/ManagerBase.cs
@@ -118,7 +118,33 @@ namespace DG.XrmFramework.BusinessLogic.Managers
                 throw new Exception(msg);
             }
         }
+        protected T GetManager<T>() where T : ManagerBase
+        {
+            if (tracingService != null)
+            {
+                tracingService.Trace($"Creating manager of type {typeof(T).Name}");
+            }
 
+            T manager;
+            if (pluginContext != null && typeof(T).GetConstructor(new[] { typeof(ITracingService), typeof(IPluginExecutionContext), typeof(IOrganizationService), typeof(IOrganizationService) }) != null)
+            {
+                manager = (T)Activator.CreateInstance(typeof(T), tracingService, pluginContext, orgService, orgAdminService);
+            }
+            else if (workflowContext != null && typeof(T).GetConstructor(new[] { typeof(ITracingService), typeof(IWorkflowContext), typeof(IOrganizationService), typeof(IOrganizationService) }) != null)
+            {
+                manager = (T)Activator.CreateInstance(typeof(T), tracingService, workflowContext, orgService, orgAdminService);
+            }
+            else if (typeof(T).GetConstructor(new[] { typeof(ITracingService), typeof(IOrganizationService), typeof(IOrganizationService) }) != null)
+            {
+                manager = (T)Activator.CreateInstance(typeof(T), tracingService, orgService, orgAdminService);
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException("No constructor found");
+            }
+
+            return manager;
+        }
         #endregion
 
         #region Private methods

--- a/XrmOrg/XrmOrg.XrmSolution/BusinessLogic/ManagerContact.cs
+++ b/XrmOrg/XrmOrg.XrmSolution/BusinessLogic/ManagerContact.cs
@@ -16,12 +16,12 @@ using Microsoft.Xrm.Sdk.Workflow;
 
 namespace DG.XrmFramework.BusinessLogic.Managers
 {
-    public class ManagerAccount : ManagerBase
+    public class ManagerContact : ManagerBase
     {
 
         #region Constructors
 
-        public ManagerAccount(
+        public ManagerContact(
             ITracingService pluginTracingService,
             IPluginExecutionContext pluginExecutionContext,
             IOrganizationService pluginOrgService,
@@ -29,7 +29,7 @@ namespace DG.XrmFramework.BusinessLogic.Managers
             : base(pluginTracingService, pluginExecutionContext,
                 pluginOrgService, pluginOrgAdminService) { }
 
-        public ManagerAccount(
+        public ManagerContact(
             ITracingService tracingService,
             IWorkflowContext workflowExecutionContext,
             IOrganizationService orgService,
@@ -37,7 +37,7 @@ namespace DG.XrmFramework.BusinessLogic.Managers
             : base(tracingService, workflowExecutionContext,
                 orgService, orgAdminService) { }
 
-        public ManagerAccount(
+        public ManagerContact(
             ITracingService tracingService,
             IOrganizationService orgService,
             IOrganizationService orgAdminService)
@@ -46,18 +46,9 @@ namespace DG.XrmFramework.BusinessLogic.Managers
         #endregion
 
 
-        public void FooPlugin(Guid primaryEntityId, bool isUpdate) {
-            var contactManager = GetManager<ManagerContact>();
-            using (var context = new Xrm(this.orgService)) {
-                var account = context.AccountSet.FirstOrDefault();
-                throw new NotImplementedException();
-            }
+        public void Baz() {
         }
-
-        public Guid BarWorkflow(Guid accountId) {
-            throw new NotImplementedException();
-        }
-        
+                
     }
 
 }


### PR DESCRIPTION
TLDR: A more compact way initialize managers.

To avoid a lot of long manager constructor calls like:
```
var bookableResourceBookingManager = new BookableResourceBookingManager(
    tracingService,
    pluginContext,
    orgService,
    orgAdminService);
```

We can just call:
```
var bookableResourceBookingManager = GetManager<BookableResourceBookingManager>();
```

This becomes espessably usefull in functions utilising manager managers. 


This will return a manager with the TraceService, OrgService, OrgAdminService and PluginContext or WorkflowContext if available.
