### PR TITLE
Added F# paths

### DIFF
--- a/rename.cmd
+++ b/rename.cmd
@@ -1,6 +1,9 @@
 @echo off
 :: Add the paths for the F# SDK (from higher version to lower)
 set FSHARPSDK=^
+C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools;^
+C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools;^
+C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools;^
 C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\FSharp;^
 C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\FSharp;^
 C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\FSharp;^


### PR DESCRIPTION
Added additional paths to for F# when renaming the framework (required by VS 2019 v16.10.0 and newer)