### PR TITLE
Added paths for VS2022

### DIFF
--- a/rename.cmd
+++ b/rename.cmd
@@ -1,6 +1,9 @@
 @echo off
 :: Add the paths for the F# SDK (from higher version to lower)
 set FSHARPSDK=^
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools;^
+C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools;^
+C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools;^
 C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools;^
 C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools;^
 C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools;^


### PR DESCRIPTION
Added paths for VS2022
On the 2 new installs i have made on new machines both have been installed into "C:\Program Files" that is why i added paths to that instead "C:\ Program Files (x86)"